### PR TITLE
Fix error on undefined identifier B57600

### DIFF
--- a/source/serial/device.d
+++ b/source/serial/device.d
@@ -54,10 +54,8 @@ import core.time;
 version(Posix)
 {
     import core.sys.posix.unistd;
-    version(Linux) {
+    version(linux) {
       import core.sys.linux.termios;
-      // unneeded, fixed in D-Programming-Language/druntime@5852cc4
-      enum B57600 = 0x1001; // 0010001
     }
     else version(OSX)
     {


### PR DESCRIPTION
Changed predefined versions from`Linux` to `linux` ([see DLang](http://dlang.org/version.html#PredefinedVersions))